### PR TITLE
Home: readable dates and full-card links (no View production)

### DIFF
--- a/app/page-content.tsx
+++ b/app/page-content.tsx
@@ -2,6 +2,7 @@
 
 import { ExperimentCard } from "@/components/experiment-card";
 import { MasonryGrid } from "@/components/masonry-grid";
+import { formatCardDate } from "@/lib/format-card-date";
 import { parseAsString, useQueryState } from "nuqs";
 import { MediaMeta } from "@/registry/ui/video";
 
@@ -13,7 +14,6 @@ interface Page {
   date?: string;
   tags: string[];
   theme?: "light" | "dark";
-  buttonLabel?: string;
   mediaMeta?: MediaMeta;
 }
 
@@ -33,7 +33,7 @@ export function PageContent({ pages }: { pages: Page[] }) {
           <ExperimentCard
             key={page.url}
             name={page.title}
-            date={page.date ?? ""}
+            date={page.date ? formatCardDate(page.date) : ""}
             media={
               page.image
                 ? {
@@ -49,7 +49,6 @@ export function PageContent({ pages }: { pages: Page[] }) {
             url={page.url}
             theme={page.theme ?? "dark"}
             textPosition="top"
-            buttonLabel={page.buttonLabel ?? undefined}
             className={isVisible(page) ? "" : "hidden"}
             priority={index < 6}
           />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -28,7 +28,6 @@ const externalProjects = [
     date: "2025-11-01",
     tags: ["Engineering"],
     theme: "light" as const,
-    buttonLabel: "View production",
     mediaMeta: getMediaMeta("/asi.webp"),
   },
   {
@@ -39,7 +38,6 @@ const externalProjects = [
     date: "2025-08-27",
     tags: ["Engineering"],
     theme: "light" as const,
-    buttonLabel: "View production",
     mediaMeta: getMediaMeta("/folder.mp4"),
   },
   {
@@ -50,7 +48,6 @@ const externalProjects = [
     date: "2025-08-11",
     tags: ["Engineering"],
     theme: "dark" as const,
-    buttonLabel: undefined,
     mediaMeta: getMediaMeta("/anywhere.mp4"),
   },
   {
@@ -61,7 +58,6 @@ const externalProjects = [
     date: "2025-07-21",
     tags: ["Engineering"],
     theme: "light" as const,
-    buttonLabel: undefined,
     mediaMeta: getMediaMeta("/agape.webp"),
   },
 ];
@@ -87,7 +83,6 @@ export default function Home() {
     date: page.data.date,
     tags: page.data.tags,
     theme: page.data.theme,
-    buttonLabel: page.data.buttonLabel,
     mediaMeta: page.data.image ? getMediaMeta(page.data.image) : undefined,
   }));
 

--- a/components/experiment-card.tsx
+++ b/components/experiment-card.tsx
@@ -1,13 +1,11 @@
 import {
   Card,
   CardContent,
-  CardFooter,
   CardHeader,
   CardTitle,
 } from "@/registry/ui/card";
 
 import { cn } from "@/lib/utils";
-import { Button } from "@/registry/ui/button";
 import { VideoWithPlaceholder, MediaMeta } from "@/registry/ui/video";
 import Image from "next/image";
 import { motion } from "motion/react";
@@ -24,7 +22,6 @@ interface ExperimentCardProps {
     meta?: MediaMeta;
   };
   url?: string;
-  buttonLabel?: string;
   className?: string;
   style?: React.CSSProperties;
   theme?: "dark" | "light";
@@ -81,7 +78,6 @@ export function ExperimentCard({
   textPosition = "bottom",
   media,
   url,
-  buttonLabel,
   className,
   style,
   theme = "light",
@@ -110,18 +106,6 @@ export function ExperimentCard({
         </CardHeader>
         {media && <Media media={media} priority={priority} />}
       </CardContent>
-
-      {buttonLabel && url && (
-        <CardFooter className="w-full p-0">
-          <Button
-            variant="secondary"
-            size="lg"
-            className="w-full group-hover/link:bg-secondary/80 transition-colors pointer-events-none"
-          >
-            {buttonLabel}
-          </Button>
-        </CardFooter>
-      )}
     </>
   );
 
@@ -136,12 +120,7 @@ export function ExperimentCard({
         )}
         style={style}
       >
-        <Card
-          className={cn(
-            "flex flex-col cursor-pointer w-full h-auto",
-            buttonLabel ? "p-1" : "p-0"
-          )}
-        >
+        <Card className="flex flex-col cursor-pointer w-full h-auto p-0">
           {cardContent}
         </Card>
       </motion.a>

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -7,7 +7,6 @@ tags: ["Engineering", "Writing"]
 image: /unified-diff-viewer.webp
 date: "2025-11-06"
 theme: "light"
-# buttonLabel: "View demo"
 ---
 
 Built for [asi.review](https://asi.review), but available as a standalone component.

--- a/lib/format-card-date.ts
+++ b/lib/format-card-date.ts
@@ -1,0 +1,18 @@
+/** Display date like "Jan 24, 2024" for ISO calendar dates (YYYY-MM-DD) without UTC shift. */
+export function formatCardDate(value: string): string {
+  const trimmed = value.trim();
+  const ymd = /^(\d{4})-(\d{2})-(\d{2})$/.exec(trimmed);
+  const date = ymd
+    ? new Date(
+        Number(ymd[1]),
+        Number(ymd[2]) - 1,
+        Number(ymd[3])
+      )
+    : new Date(trimmed);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}

--- a/source.config.ts
+++ b/source.config.ts
@@ -39,7 +39,6 @@ export const docs = defineDocs({
       image: z.string().optional(),
       date: z.string().optional(),
       theme: z.enum(["light", "dark"]).optional(),
-      buttonLabel: z.string().optional(),
     }),
   },
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Removed the secondary **View production** footer from project cards. Each card is already a single link (`motion.a` wrapping the card), so the whole card—including title, date, and media—remains the click target.
- Dates on the home grid now render in short US style (e.g. **Nov 1, 2025**) instead of ISO `YYYY-MM-DD`. `YYYY-MM-DD` values from frontmatter are parsed as calendar dates in the local timezone to avoid off-by-one when crossing UTC midnight.
- Dropped the unused `buttonLabel` field from the MDX frontmatter schema and the sample comment in `content/docs/index.mdx`.

## Testing

- `npm run test` (Vitest): all passed.
- `npm run build`: succeeded (OG fetch warnings during static generation are unrelated to this change).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a460ff9a-6197-46dd-93d0-31fce9531655"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a460ff9a-6197-46dd-93d0-31fce9531655"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

