### PR TITLE
Add in-cloud component route

### DIFF
--- a/app/in-cloud/page.tsx
+++ b/app/in-cloud/page.tsx
@@ -1,0 +1,5 @@
+import { InCloud } from "@/components/in-cloud";
+
+export default function InCloudPage() {
+  return <InCloud />;
+}

--- a/components/in-cloud.tsx
+++ b/components/in-cloud.tsx
@@ -1,0 +1,41 @@
+const steps = [
+  "Inspect the project shape",
+  "Match local component style",
+  "Commit, push, and open a draft PR",
+];
+
+export function InCloud() {
+  return (
+    <section className="mx-auto flex min-h-svh w-full max-w-4xl flex-col justify-center px-4 py-16 sm:px-6">
+      <div className="rounded-3xl border bg-card p-6 text-card-foreground shadow-sm sm:p-10">
+        <p className="mb-4 text-sm font-medium uppercase tracking-[0.2em] text-muted-foreground">
+          Cursor Cloud
+        </p>
+        <div className="grid gap-8 lg:grid-cols-[1fr_18rem] lg:items-end">
+          <div className="space-y-5">
+            <h1 className="text-4xl font-medium tracking-tight sm:text-5xl">
+              Built in the cloud
+            </h1>
+            <p className="max-w-2xl text-base leading-7 text-muted-foreground sm:text-lg">
+              A small route-backed component added by a cloud agent, following
+              the app&apos;s existing Tailwind and App Router conventions.
+            </p>
+          </div>
+          <ol className="grid gap-3 text-sm text-muted-foreground">
+            {steps.map((step, index) => (
+              <li
+                key={step}
+                className="flex items-center gap-3 rounded-2xl border bg-background/60 p-3"
+              >
+                <span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-primary text-xs font-medium text-primary-foreground">
+                  {index + 1}
+                </span>
+                {step}
+              </li>
+            ))}
+          </ol>
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a small `InCloud` component using existing Tailwind/card styling conventions
- Expose the component at the `/in-cloud` App Router route

## Testing
- Attempted `pnpm exec tsc --noEmit` (blocked: `pnpm` is not installed in the cloud image)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="http://localhost:4000/agents/bc-a86fd804-df66-48f6-b507-27ec982ebfcc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="http://localhost:4000/background-agent?bcId=bc-a86fd804-df66-48f6-b507-27ec982ebfcc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

