### PR TITLE
Add select registry component

### DIFF
--- a/public/r/dropdown.json
+++ b/public/r/dropdown.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "dropdown",
+  "type": "registry:component",
+  "title": "Dropdown",
+  "description": "Native details-based dropdown menu",
+  "dependencies": [
+    "lucide-react"
+  ],
+  "files": [
+    {
+      "path": "registry/ui/dropdown.tsx",
+      "content": "\"use client\"\n\nimport * as React from \"react\"\nimport { ChevronDownIcon } from \"lucide-react\"\n\nimport { cn } from \"@/lib/utils\"\n\nfunction Dropdown({\n  className,\n  ...props\n}: React.ComponentProps<\"details\">) {\n  return (\n    <details\n      data-slot=\"dropdown\"\n      className={cn(\"group/dropdown relative inline-block\", className)}\n      {...props}\n    />\n  )\n}\n\nfunction DropdownTrigger({\n  className,\n  children,\n  ...props\n}: React.ComponentProps<\"summary\">) {\n  return (\n    <summary\n      data-slot=\"dropdown-trigger\"\n      className={cn(\n        \"border-input bg-background hover:bg-accent hover:text-accent-foreground focus-visible:border-ring focus-visible:ring-ring/50 inline-flex h-9 cursor-pointer list-none items-center justify-center gap-2 rounded-md border px-3 py-2 text-sm font-medium whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] select-none [&::-webkit-details-marker]:hidden\",\n        className\n      )}\n      {...props}\n    >\n      {children}\n      <ChevronDownIcon className=\"size-4 shrink-0 opacity-50 transition-transform group-open/dropdown:rotate-180\" />\n    </summary>\n  )\n}\n\nfunction DropdownContent({\n  className,\n  align = \"start\",\n  ...props\n}: React.ComponentProps<\"div\"> & {\n  align?: \"start\" | \"center\" | \"end\"\n}) {\n  return (\n    <div\n      data-slot=\"dropdown-content\"\n      className={cn(\n        \"bg-popover text-popover-foreground absolute z-50 mt-2 min-w-40 origin-top rounded-md border p-1 shadow-md\",\n        \"group-open/dropdown:animate-in group-open/dropdown:fade-in-0 group-open/dropdown:zoom-in-95\",\n        align === \"start\" && \"left-0\",\n        align === \"center\" && \"left-1/2 -translate-x-1/2\",\n        align === \"end\" && \"right-0\",\n        className\n      )}\n      {...props}\n    />\n  )\n}\n\nfunction DropdownItem({\n  className,\n  ...props\n}: React.ComponentProps<\"button\">) {\n  return (\n    <button\n      type=\"button\"\n      data-slot=\"dropdown-item\"\n      className={cn(\n        \"focus:bg-accent focus:text-accent-foreground hover:bg-accent hover:text-accent-foreground flex w-full cursor-pointer items-center rounded-sm px-2 py-1.5 text-left text-sm outline-none transition-colors disabled:pointer-events-none disabled:opacity-50\",\n        className\n      )}\n      {...props}\n    />\n  )\n}\n\nexport { Dropdown, DropdownTrigger, DropdownContent, DropdownItem }\n",
+      "type": "registry:component",
+      "target": "components/ui/dropdown.tsx"
+    }
+  ]
+}

--- a/public/r/hover-card.json
+++ b/public/r/hover-card.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "hover-card",
+  "type": "registry:component",
+  "title": "Hover Card",
+  "description": "Preview content that appears on hover",
+  "dependencies": [
+    "@radix-ui/react-hover-card"
+  ],
+  "files": [
+    {
+      "path": "registry/ui/hover-card.tsx",
+      "content": "\"use client\"\n\nimport * as React from \"react\"\nimport * as HoverCardPrimitive from \"@radix-ui/react-hover-card\"\n\nimport { cn } from \"@/lib/utils\"\n\nfunction HoverCard({\n  ...props\n}: React.ComponentProps<typeof HoverCardPrimitive.Root>) {\n  return <HoverCardPrimitive.Root data-slot=\"hover-card\" {...props} />\n}\n\nfunction HoverCardTrigger({\n  ...props\n}: React.ComponentProps<typeof HoverCardPrimitive.Trigger>) {\n  return (\n    <HoverCardPrimitive.Trigger data-slot=\"hover-card-trigger\" {...props} />\n  )\n}\n\nfunction HoverCardContent({\n  className,\n  align = \"center\",\n  sideOffset = 4,\n  ...props\n}: React.ComponentProps<typeof HoverCardPrimitive.Content>) {\n  return (\n    <HoverCardPrimitive.Portal data-slot=\"hover-card-portal\">\n      <HoverCardPrimitive.Content\n        data-slot=\"hover-card-content\"\n        align={align}\n        sideOffset={sideOffset}\n        className={cn(\n          \"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-64 origin-(--radix-hover-card-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden\",\n          className\n        )}\n        {...props}\n      />\n    </HoverCardPrimitive.Portal>\n  )\n}\n\nexport { HoverCard, HoverCardTrigger, HoverCardContent }\n",
+      "type": "registry:component",
+      "target": "components/ui/hover-card.tsx"
+    }
+  ]
+}

--- a/public/r/registry.json
+++ b/public/r/registry.json
@@ -144,6 +144,20 @@
           "target": "components/ui/hover-card.tsx"
         }
       ]
+    },
+    {
+      "name": "dropdown",
+      "type": "registry:component",
+      "title": "Dropdown",
+      "description": "Native details-based dropdown menu",
+      "dependencies": ["lucide-react"],
+      "files": [
+        {
+          "path": "registry/ui/dropdown.tsx",
+          "type": "registry:component",
+          "target": "components/ui/dropdown.tsx"
+        }
+      ]
     }
   ]
 }

--- a/public/r/registry.json
+++ b/public/r/registry.json
@@ -116,6 +116,20 @@
           "target": "components/ui/button.tsx"
         }
       ]
+    },
+    {
+      "name": "select",
+      "type": "registry:component",
+      "title": "Select",
+      "description": "Native select input with project styling",
+      "dependencies": ["lucide-react"],
+      "files": [
+        {
+          "path": "registry/ui/select.tsx",
+          "type": "registry:component",
+          "target": "components/ui/select.tsx"
+        }
+      ]
     }
   ]
 }

--- a/public/r/registry.json
+++ b/public/r/registry.json
@@ -130,6 +130,20 @@
           "target": "components/ui/select.tsx"
         }
       ]
+    },
+    {
+      "name": "hover-card",
+      "type": "registry:component",
+      "title": "Hover Card",
+      "description": "Preview content that appears on hover",
+      "dependencies": ["@radix-ui/react-hover-card"],
+      "files": [
+        {
+          "path": "registry/ui/hover-card.tsx",
+          "type": "registry:component",
+          "target": "components/ui/hover-card.tsx"
+        }
+      ]
     }
   ]
 }

--- a/public/r/select.json
+++ b/public/r/select.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "select",
+  "type": "registry:component",
+  "title": "Select",
+  "description": "Native select input with project styling",
+  "dependencies": [
+    "lucide-react"
+  ],
+  "files": [
+    {
+      "path": "registry/ui/select.tsx",
+      "content": "import * as React from \"react\";\nimport { ChevronDownIcon } from \"lucide-react\";\n\nimport { cn } from \"@/lib/utils\";\n\nfunction Select({\n  className,\n  children,\n  ...props\n}: React.ComponentProps<\"select\">) {\n  return (\n    <div data-slot=\"select-wrapper\" className=\"relative w-full\">\n      <select\n        data-slot=\"select\"\n        className={cn(\n          \"border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex h-9 w-full appearance-none rounded-md border bg-transparent px-3 py-1 pr-8 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm\",\n          className\n        )}\n        {...props}\n      >\n        {children}\n      </select>\n      <ChevronDownIcon\n        data-slot=\"select-icon\"\n        className=\"text-muted-foreground pointer-events-none absolute top-1/2 right-3 size-4 -translate-y-1/2 opacity-50\"\n      />\n    </div>\n  );\n}\n\nexport { Select };\n",
+      "type": "registry:component",
+      "target": "components/ui/select.tsx"
+    }
+  ]
+}

--- a/registry.json
+++ b/registry.json
@@ -144,6 +144,20 @@
           "target": "components/ui/hover-card.tsx"
         }
       ]
+    },
+    {
+      "name": "dropdown",
+      "type": "registry:component",
+      "title": "Dropdown",
+      "description": "Native details-based dropdown menu",
+      "dependencies": ["lucide-react"],
+      "files": [
+        {
+          "path": "registry/ui/dropdown.tsx",
+          "type": "registry:component",
+          "target": "components/ui/dropdown.tsx"
+        }
+      ]
     }
   ]
 }

--- a/registry.json
+++ b/registry.json
@@ -116,6 +116,20 @@
           "target": "components/ui/button.tsx"
         }
       ]
+    },
+    {
+      "name": "select",
+      "type": "registry:component",
+      "title": "Select",
+      "description": "Native select input with project styling",
+      "dependencies": ["lucide-react"],
+      "files": [
+        {
+          "path": "registry/ui/select.tsx",
+          "type": "registry:component",
+          "target": "components/ui/select.tsx"
+        }
+      ]
     }
   ]
 }

--- a/registry.json
+++ b/registry.json
@@ -130,6 +130,20 @@
           "target": "components/ui/select.tsx"
         }
       ]
+    },
+    {
+      "name": "hover-card",
+      "type": "registry:component",
+      "title": "Hover Card",
+      "description": "Preview content that appears on hover",
+      "dependencies": ["@radix-ui/react-hover-card"],
+      "files": [
+        {
+          "path": "registry/ui/hover-card.tsx",
+          "type": "registry:component",
+          "target": "components/ui/hover-card.tsx"
+        }
+      ]
     }
   ]
 }

--- a/registry/ui/dropdown.tsx
+++ b/registry/ui/dropdown.tsx
@@ -1,0 +1,81 @@
+"use client"
+
+import * as React from "react"
+import { ChevronDownIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Dropdown({
+  className,
+  ...props
+}: React.ComponentProps<"details">) {
+  return (
+    <details
+      data-slot="dropdown"
+      className={cn("group/dropdown relative inline-block", className)}
+      {...props}
+    />
+  )
+}
+
+function DropdownTrigger({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<"summary">) {
+  return (
+    <summary
+      data-slot="dropdown-trigger"
+      className={cn(
+        "border-input bg-background hover:bg-accent hover:text-accent-foreground focus-visible:border-ring focus-visible:ring-ring/50 inline-flex h-9 cursor-pointer list-none items-center justify-center gap-2 rounded-md border px-3 py-2 text-sm font-medium whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] select-none [&::-webkit-details-marker]:hidden",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronDownIcon className="size-4 shrink-0 opacity-50 transition-transform group-open/dropdown:rotate-180" />
+    </summary>
+  )
+}
+
+function DropdownContent({
+  className,
+  align = "start",
+  ...props
+}: React.ComponentProps<"div"> & {
+  align?: "start" | "center" | "end"
+}) {
+  return (
+    <div
+      data-slot="dropdown-content"
+      className={cn(
+        "bg-popover text-popover-foreground absolute z-50 mt-2 min-w-40 origin-top rounded-md border p-1 shadow-md",
+        "group-open/dropdown:animate-in group-open/dropdown:fade-in-0 group-open/dropdown:zoom-in-95",
+        align === "start" && "left-0",
+        align === "center" && "left-1/2 -translate-x-1/2",
+        align === "end" && "right-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownItem({
+  className,
+  ...props
+}: React.ComponentProps<"button">) {
+  return (
+    <button
+      type="button"
+      data-slot="dropdown-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground hover:bg-accent hover:text-accent-foreground flex w-full cursor-pointer items-center rounded-sm px-2 py-1.5 text-left text-sm outline-none transition-colors disabled:pointer-events-none disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Dropdown, DropdownTrigger, DropdownContent, DropdownItem }

--- a/registry/ui/hover-card.tsx
+++ b/registry/ui/hover-card.tsx
@@ -1,0 +1,44 @@
+"use client"
+
+import * as React from "react"
+import * as HoverCardPrimitive from "@radix-ui/react-hover-card"
+
+import { cn } from "@/lib/utils"
+
+function HoverCard({
+  ...props
+}: React.ComponentProps<typeof HoverCardPrimitive.Root>) {
+  return <HoverCardPrimitive.Root data-slot="hover-card" {...props} />
+}
+
+function HoverCardTrigger({
+  ...props
+}: React.ComponentProps<typeof HoverCardPrimitive.Trigger>) {
+  return (
+    <HoverCardPrimitive.Trigger data-slot="hover-card-trigger" {...props} />
+  )
+}
+
+function HoverCardContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof HoverCardPrimitive.Content>) {
+  return (
+    <HoverCardPrimitive.Portal data-slot="hover-card-portal">
+      <HoverCardPrimitive.Content
+        data-slot="hover-card-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-64 origin-(--radix-hover-card-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+          className
+        )}
+        {...props}
+      />
+    </HoverCardPrimitive.Portal>
+  )
+}
+
+export { HoverCard, HoverCardTrigger, HoverCardContent }

--- a/registry/ui/select.tsx
+++ b/registry/ui/select.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+import { ChevronDownIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+function Select({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<"select">) {
+  return (
+    <div data-slot="select-wrapper" className="relative w-full">
+      <select
+        data-slot="select"
+        className={cn(
+          "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex h-9 w-full appearance-none rounded-md border bg-transparent px-3 py-1 pr-8 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </select>
+      <ChevronDownIcon
+        data-slot="select-icon"
+        className="text-muted-foreground pointer-events-none absolute top-1/2 right-3 size-4 -translate-y-1/2 opacity-50"
+      />
+    </div>
+  );
+}
+
+export { Select };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a small native Select component under `registry/ui/select.tsx`
- Add a minimal Radix Hover Card component under `registry/ui/hover-card.tsx`
- Add a small native details-based Dropdown component under `registry/ui/dropdown.tsx`
- Register the new components in `registry.json`
- Add generated registry payloads under `public/r/` and update `public/r/registry.json`

## Verification
- `python3 -m json.tool registry.json`
- `python3 -m json.tool public/r/registry.json`
- `python3 -m json.tool public/r/select.json`
- `python3 -m json.tool public/r/hover-card.json`
- `python3 -m json.tool public/r/dropdown.json`
- Python payload assertions: component sources match their `public/r/*.json` payloads, registry indexes include the new components, and dropdown/hover-card metadata matches between registry indexes

Note: `pnpm registry:build && pnpm exec tsc --noEmit` could not run because this cloud image does not have Node/pnpm installed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="http://localhost:4000/agents/bc-01e033b2-bbd9-4b68-b2ee-95f30473d3c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="http://localhost:4000/background-agent?bcId=bc-01e033b2-bbd9-4b68-b2ee-95f30473d3c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

