### PR TITLE
Add skeleton UI component

### DIFF
--- a/components/ui/skeleton.tsx
+++ b/components/ui/skeleton.tsx
@@ -1,0 +1,15 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("bg-accent animate-pulse rounded-md", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/public/r/registry.json
+++ b/public/r/registry.json
@@ -4,6 +4,19 @@
   "homepage": "https://ui.fredrika.dev",
   "items": [
     {
+      "name": "skeleton",
+      "type": "registry:component",
+      "title": "Skeleton",
+      "description": "Placeholder loading state component",
+      "files": [
+        {
+          "path": "registry/ui/skeleton.tsx",
+          "type": "registry:component",
+          "target": "components/ui/skeleton.tsx"
+        }
+      ]
+    },
+    {
       "name": "diff-viewer",
       "type": "registry:component",
       "title": "Diff Viewer",

--- a/public/r/skeleton.json
+++ b/public/r/skeleton.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "skeleton",
+  "type": "registry:component",
+  "title": "Skeleton",
+  "description": "Placeholder loading state component",
+  "files": [
+    {
+      "path": "registry/ui/skeleton.tsx",
+      "content": "import * as React from \"react\";\n\nimport { cn } from \"@/lib/utils\";\n\nfunction Skeleton({ className, ...props }: React.ComponentProps<\"div\">) {\n  return (\n    <div\n      data-slot=\"skeleton\"\n      className={cn(\"bg-accent animate-pulse rounded-md\", className)}\n      {...props}\n    />\n  );\n}\n\nexport { Skeleton };\n",
+      "type": "registry:component",
+      "target": "components/ui/skeleton.tsx"
+    }
+  ]
+}

--- a/registry.json
+++ b/registry.json
@@ -4,6 +4,19 @@
   "homepage": "https://ui.fredrika.dev",
   "items": [
     {
+      "name": "skeleton",
+      "type": "registry:component",
+      "title": "Skeleton",
+      "description": "Placeholder loading state component",
+      "files": [
+        {
+          "path": "registry/ui/skeleton.tsx",
+          "type": "registry:component",
+          "target": "components/ui/skeleton.tsx"
+        }
+      ]
+    },
+    {
       "name": "diff-viewer",
       "type": "registry:component",
       "title": "Diff Viewer",

--- a/registry/ui/skeleton.tsx
+++ b/registry/ui/skeleton.tsx
@@ -1,0 +1,15 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("bg-accent animate-pulse rounded-md", className)}
+      {...props}
+    />
+  );
+}
+
+export { Skeleton };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a small `Skeleton` loading placeholder component under `components/ui`.
- Register the component in the shadcn registry source and generated `public/r` artifacts.

## Verification
- `python3` JSON/structure check for `registry.json`, `public/r/registry.json`, and `public/r/skeleton.json`
- `pnpm registry:build` could not run because this cloud image does not have Node/pnpm installed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="http://localhost:4000/agents/bc-9530908d-844c-4fb4-b59d-1a1280980409"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="http://localhost:4000/background-agent?bcId=bc-9530908d-844c-4fb4-b59d-1a1280980409"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

